### PR TITLE
Replace deprecated 'new Integer' with 'Integer.valueOf'

### DIFF
--- a/labs/todojse/src/main/java/com/redhat/training/TestTodoMap.java
+++ b/labs/todojse/src/main/java/com/redhat/training/TestTodoMap.java
@@ -41,14 +41,14 @@ public class TestTodoMap {
 		// Display an todo record
 		case 'R':
 			System.out.println("Enter int value for item id: ");
-			id = new Integer(in.readLine().trim());
+			id = Integer.valueOf(in.readLine().trim());
 			todo.findItemTodo(id);
 			break;
 
 		// Mark an existing task as completed
 		case 'C':
 			System.out.println("Enter int value for item id: ");
-			id = new Integer(in.readLine().trim());
+			id = Integer.valueOf(in.readLine().trim());
 			todo.completeTodo(id);
 			break;
 
@@ -56,7 +56,7 @@ public class TestTodoMap {
 		// Delete an todo record
 		case 'D':
 			System.out.println("Enter int value for item id: ");
-			id = new Integer(in.readLine().trim());
+			id = Integer.valueOf(in.readLine().trim());
 			todo.deleteTodo(id);
 			System.out.println("Deleted item " + id);
 			break;

--- a/labs/todojse/src/main/java/com/redhat/training/TodoMap.java
+++ b/labs/todojse/src/main/java/com/redhat/training/TodoMap.java
@@ -34,7 +34,7 @@ public class TodoMap {
 				status = Status.PENDING.toString();
 
 			item.setStatus(status);
-			todoMap.put(new Integer(count), item);
+			todoMap.put(Integer.valueOf(count), item);
 			System.out.println("Do you want to add more items[Y/N]");
 			ans = scn.next().toUpperCase();
 


### PR DESCRIPTION
Red Hat CodeReady Studio says:
`The constructor Integer(String) is deprecated`

Fix by replacing `new Integer` with `Integer.valueOf`